### PR TITLE
UPT: Fix the go mod name.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module git.easygroup.co/lalamove/nui
+module github.com/lalamove/nui
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
# Objective
As kconfig is required nui in `go mod` if the module name of `nui` is incorrect. public user will not able to access kconfig via `go mod`

# screen shot
![image](https://user-images.githubusercontent.com/5622516/51510296-7b2b9880-1e37-11e9-88e3-23476d6e6c4a.png)

# expected 
It will pass the testcase

# actual
Cannot access `nui` due to incorrect module name.

cc @francoispqt   