### PR TITLE
Add a structured interface to nlogger

### DIFF
--- a/nlogger/basic.go
+++ b/nlogger/basic.go
@@ -1,0 +1,126 @@
+package nlogger
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Basic logger interface provides a very basic logger with functions that prints
+// messages corresponding to the log level picked
+type Basic interface {
+	Debug(string)
+	Info(string)
+	Warn(string)
+	Error(string)
+	Fatal(string)
+}
+
+// ToStructured lets you use a simple logger that conforms to the Basic
+// interface to satisfy the needs of packages that use the Structured logger
+func ToStructured(logger Basic) Structured {
+	return &basicStructured{logger: logger}
+}
+
+// From here and below follows an implementation that wraps a basic logger into a
+// private struct that conforms to the Structured logger interface. Some speed
+// considerations have been made, but not a lot
+type entry struct {
+	builder strings.Builder
+}
+
+func (e *entry) format(key string, value string) {
+	e.builder.WriteRune(' ')
+	e.builder.WriteString(key)
+	e.builder.WriteRune('=')
+	e.builder.WriteString(value)
+}
+
+func (e *entry) String(key string, value string) Entry {
+	e.format(key, value)
+	return e
+}
+
+func (e *entry) Int(key string, value int) Entry {
+	e.format(key, strconv.Itoa(value))
+	return e
+}
+
+func (e *entry) Int64(key string, value int64) Entry {
+	e.format(key, fmt.Sprintf("%d", value))
+	return e
+}
+
+func (e *entry) Float(key string, value float64) Entry {
+	e.format(key, fmt.Sprintf("%f", value))
+	return e
+}
+
+func (e *entry) Bool(key string, value bool) Entry {
+	e.format(key, strconv.FormatBool(value))
+	return e
+}
+
+func (e *entry) Err(key string, value error) Entry {
+	e.format(key, value.Error())
+	return e
+}
+
+type basicStructured struct {
+	logger Basic
+}
+
+func (b *basicStructured) Debug(msg string) {
+	b.logger.Debug(msg)
+}
+
+func (b *basicStructured) DebugWithFields(msg string, ef EntryFunc) {
+	var e = &entry{}
+	e.builder.WriteString(msg)
+	ef(e)
+	b.logger.Debug(e.builder.String())
+}
+
+func (b *basicStructured) Info(msg string) {
+	b.logger.Info(msg)
+}
+
+func (b *basicStructured) InfoWithFields(msg string, ef EntryFunc) {
+	var e = &entry{}
+	e.builder.WriteString(msg)
+	ef(e)
+	b.logger.Info(e.builder.String())
+}
+
+func (b *basicStructured) Warn(msg string) {
+	b.logger.Warn(msg)
+}
+
+func (b *basicStructured) WarnWithFields(msg string, ef EntryFunc) {
+	var e = &entry{}
+	e.builder.WriteString(msg)
+	ef(e)
+	b.logger.Warn(e.builder.String())
+}
+
+func (b *basicStructured) Error(msg string) {
+	b.logger.Error(msg)
+}
+
+func (b *basicStructured) ErrorWithFields(msg string, ef EntryFunc) {
+	var e = &entry{}
+	e.builder.WriteString(msg)
+	ef(e)
+	b.logger.Error(e.builder.String())
+}
+
+func (b *basicStructured) Fatal(msg string) {
+	b.logger.Fatal(msg)
+}
+
+func (b *basicStructured) FatalWithFields(msg string, ef EntryFunc) {
+	var e = &entry{}
+	e.builder.WriteString(msg)
+	ef(e)
+	b.logger.Fatal(e.builder.String())
+}

--- a/nlogger/basic.go
+++ b/nlogger/basic.go
@@ -36,34 +36,28 @@ func (e *entry) format(key string, value string) {
 	e.builder.WriteString(value)
 }
 
-func (e *entry) String(key string, value string) Entry {
+func (e *entry) String(key string, value string) {
 	e.format(key, value)
-	return e
 }
 
-func (e *entry) Int(key string, value int) Entry {
+func (e *entry) Int(key string, value int) {
 	e.format(key, strconv.Itoa(value))
-	return e
 }
 
-func (e *entry) Int64(key string, value int64) Entry {
+func (e *entry) Int64(key string, value int64) {
 	e.format(key, fmt.Sprintf("%d", value))
-	return e
 }
 
-func (e *entry) Float(key string, value float64) Entry {
+func (e *entry) Float(key string, value float64) {
 	e.format(key, fmt.Sprintf("%f", value))
-	return e
 }
 
-func (e *entry) Bool(key string, value bool) Entry {
+func (e *entry) Bool(key string, value bool) {
 	e.format(key, strconv.FormatBool(value))
-	return e
 }
 
-func (e *entry) Err(key string, value error) Entry {
+func (e *entry) Err(key string, value error) {
 	e.format(key, value.Error())
-	return e
 }
 
 type basicStructured struct {

--- a/nlogger/basic.go
+++ b/nlogger/basic.go
@@ -60,6 +60,14 @@ func (e *entry) Err(key string, value error) {
 	e.format(key, value.Error())
 }
 
+func (e *entry) ObjectFunc(key string, value EntryFunc) {
+	e.builder.WriteRune(' ')
+	e.builder.WriteString(key)
+	e.builder.WriteString("={")
+	value(e)
+	e.builder.WriteString(" }")
+}
+
 type basicStructured struct {
 	logger Basic
 }

--- a/nlogger/log.go
+++ b/nlogger/log.go
@@ -1,21 +1,9 @@
 package nlogger
 
 import (
-	"context"
-	"errors"
 	"io"
 	"log"
-	"sync"
-	"sync/atomic"
 )
-
-type loggerKey string
-
-// LoggerKey is the key to access the logger in context
-const LoggerKey loggerKey = "logger"
-
-// ErrLoggerNotFoundInContext is the error when calling MustFromContext and the logger is not found
-var ErrLoggerNotFoundInContext = errors.New("Logger not found in context")
 
 // Logger is a generic Logger interface
 type Logger interface {
@@ -26,13 +14,14 @@ type Logger interface {
 	Fatal(string)
 }
 
-type defaultLogger struct {
-	*log.Logger
+// New will return a default logger instance
+func New(target io.Writer, prefix string) Structured {
+	// wrapedy wrap!
+	return &basicStructured{&defaultLogger{log.New(target, prefix, log.LstdFlags)}}
 }
 
-// New will return a default logger instance
-func New(target io.Writer, prefix string) Logger {
-	return &defaultLogger{log.New(target, prefix, log.LstdFlags)}
+type defaultLogger struct {
+	*log.Logger
 }
 
 // Debug will print the message in debug level
@@ -58,64 +47,4 @@ func (dl *defaultLogger) Error(msg string) {
 // Fatal will print the message in fatal level and kill the main process
 func (dl *defaultLogger) Fatal(msg string) {
 	dl.Logger.Fatal(msg)
-}
-
-// SetInContext sets the logger in a context and returns the new context
-func SetInContext(ctx context.Context, logger Logger) context.Context {
-	return context.WithValue(ctx, LoggerKey, logger)
-}
-
-// FromContext gets the logger from context.
-// If context does not exist, it returns nil.
-func FromContext(ctx context.Context) Logger {
-	var v = ctx.Value(LoggerKey)
-	if v == nil {
-		return nil
-	}
-	return v.(Logger)
-}
-
-// MustFromContext gets the logger from context.
-// If context does not exist, it panics with a ErrLoggerNotFoundInContext.
-func MustFromContext(ctx context.Context) Logger {
-	var v = ctx.Value(LoggerKey)
-	if v == nil {
-		panic(ErrLoggerNotFoundInContext)
-	}
-	return v.(Logger)
-}
-
-// Provider is an interface to get a thread safe logger provider with
-// the ability to replace the internal logger provided
-type Provider interface {
-	// Get returns the Provider's attached logger in a thread safe manner
-	Get() Logger
-	// Replace replaces the provider's internal logger in a thread safe manner
-	Replace(Logger)
-}
-
-type provider struct {
-	v   *atomic.Value
-	mut *sync.Mutex
-}
-
-// NewProvider returns a new Logger Provider from the given Logger l
-func NewProvider(l Logger) Provider {
-	var v atomic.Value
-	v.Store(l)
-
-	return &provider{
-		v:   &v,
-		mut: &sync.Mutex{},
-	}
-}
-
-func (s *provider) Get() Logger {
-	return s.v.Load().(Logger)
-}
-
-func (s *provider) Replace(l Logger) {
-	s.mut.Lock()
-	s.v.Store(l)
-	s.mut.Unlock()
 }

--- a/nlogger/structured.go
+++ b/nlogger/structured.go
@@ -1,0 +1,106 @@
+package nlogger
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+)
+
+type loggerKey string
+
+// LoggerKey is the key to access the logger in context
+const LoggerKey loggerKey = "nlogger.Structured"
+
+// ErrLoggerNotFoundInContext is the error when calling MustFromContext and the logger is not found
+var ErrLoggerNotFoundInContext = errors.New("Logger not found in context")
+
+// Entry represents a single log line and is what you use in the *WithFields callback.
+// You would call any of the functions in the interface to add a keyed value to the log line.
+type Entry interface {
+	String(key string, value string) Entry
+	Int(key string, value int) Entry
+	Int64(key string, value int64) Entry
+	Float(key string, value float64) Entry
+	Bool(key string, value bool) Entry
+	Err(key string, value error) Entry
+}
+
+// EntryFunc defines the callback that you implement when using the *WithFields function
+type EntryFunc func(Entry) Entry
+
+// Structured is a generic structured logger that allows you to add fields to log messages
+type Structured interface {
+	Debug(string)
+	DebugWithFields(string, EntryFunc)
+	Info(string)
+	InfoWithFields(string, EntryFunc)
+	Warn(string)
+	WarnWithFields(string, EntryFunc)
+	Error(string)
+	ErrorWithFields(string, EntryFunc)
+	Fatal(string)
+	FatalWithFields(string, EntryFunc)
+}
+
+// SetInContext sets the logger in a context and returns the new context
+func SetInContext(ctx context.Context, logger Structured) context.Context {
+	return context.WithValue(ctx, LoggerKey, logger)
+}
+
+// FromContext gets the logger from context.
+// If context does not exist, it returns nil.
+func FromContext(ctx context.Context) Structured {
+	var v = ctx.Value(LoggerKey)
+	if v == nil {
+		return nil
+	}
+	return v.(Structured)
+}
+
+// MustFromContext gets the logger from context.
+// If context does not exist, it panics with a ErrLoggerNotFoundInContext.
+func MustFromContext(ctx context.Context) Structured {
+	var v = ctx.Value(LoggerKey)
+	if v == nil {
+		panic(ErrLoggerNotFoundInContext)
+	}
+	return v.(Structured)
+}
+
+// Provider is an interface to get a thread safe logger provider with
+// the ability to replace the internal logger provided
+type Provider interface {
+	// Get returns the Provider's attached logger in a thread safe manner
+	Get() Structured
+	// Replace replaces the provider's internal logger in a thread safe manner
+	Replace(Structured)
+}
+
+type provider struct {
+	v   *atomic.Value
+	mut *sync.Mutex
+}
+
+// NewProvider returns a new Structured Provider from the given Logger l
+func NewProvider(l Structured) Provider {
+	var v atomic.Value
+	v.Store(l)
+
+	return &provider{
+		v:   &v,
+		mut: &sync.Mutex{},
+	}
+}
+
+// Get returns the attached Structured logger
+func (s *provider) Get() Structured {
+	return s.v.Load().(Structured)
+}
+
+// Replace the logger inside the Provider
+func (s *provider) Replace(l Structured) {
+	s.mut.Lock()
+	s.v.Store(l)
+	s.mut.Unlock()
+}

--- a/nlogger/structured.go
+++ b/nlogger/structured.go
@@ -24,6 +24,7 @@ type Entry interface {
 	Float(key string, value float64)
 	Bool(key string, value bool)
 	Err(key string, value error)
+	ObjectFunc(key string, value EntryFunc)
 }
 
 // EntryFunc defines the callback that you implement when using the *WithFields function

--- a/nlogger/structured.go
+++ b/nlogger/structured.go
@@ -18,16 +18,16 @@ var ErrLoggerNotFoundInContext = errors.New("Logger not found in context")
 // Entry represents a single log line and is what you use in the *WithFields callback.
 // You would call any of the functions in the interface to add a keyed value to the log line.
 type Entry interface {
-	String(key string, value string) Entry
-	Int(key string, value int) Entry
-	Int64(key string, value int64) Entry
-	Float(key string, value float64) Entry
-	Bool(key string, value bool) Entry
-	Err(key string, value error) Entry
+	String(key string, value string)
+	Int(key string, value int)
+	Int64(key string, value int64)
+	Float(key string, value float64)
+	Bool(key string, value bool)
+	Err(key string, value error)
 }
 
 // EntryFunc defines the callback that you implement when using the *WithFields function
-type EntryFunc func(Entry) Entry
+type EntryFunc func(Entry)
 
 // Structured is a generic structured logger that allows you to add fields to log messages
 type Structured interface {


### PR DESCRIPTION
This adds Structured and Entry as interfaces to `nlogger` and also makes Structured the default implementation. There's a new interface called Basic as well, but for now we're keeping Logger around just to not break the world for everyone that updates just yet. However, the context functions (recently introduced) have been changed to deal with the Structured logger interface rather than Logger.

This also introduces a function called ToStructured() which takes a logger that implements a Basic logger and wraps it into an implementation of Structured. This allows people to still use a simple logger with our libraries, but we can fully implement a structured logger throughout the codebase.

The Logger interface is deprecated and will be removed.

Would be okay to move back the Context and Provider implementations to log.go.