### PR TITLE
Add NewWithLog to support usage of log.Logger

### DIFF
--- a/nlogger/log.go
+++ b/nlogger/log.go
@@ -20,6 +20,12 @@ func New(target io.Writer, prefix string) Structured {
 	return &basicStructured{&defaultLogger{log.New(target, prefix, log.LstdFlags)}}
 }
 
+// NewWithLog allows you to pass in a log.Logger which then gets snuggly wrapped in
+// an interface that suits the nlogger.Structured interface.
+func NewWithLog(log *log.Logger) Structured {
+	return &basicStructured{&defaultLogger{log}}
+}
+
 type defaultLogger struct {
 	*log.Logger
 }


### PR DESCRIPTION
Some users use the bare `log.Logger` implementation from the standard library, we can make their lives easier by providing a simple function that gives them access to the `nlogger.defaultLogger` struct wrapper.

Addresses #5