### PR TITLE
Method to create span from context and return new context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go:
   - "1.10.x"
   - "1.11.x"
-  - master
+  - "1.12.x"
 
 script:
   - go get -u golang.org/x/lint/golint

--- a/ntracing/ntracing.go
+++ b/ntracing/ntracing.go
@@ -33,12 +33,8 @@ func NewChildSpanAndContext(
 	ctx context.Context,
 	name string,
 ) (opentracing.Span, context.Context, bool) {
-	if span, ok := ctx.Value(SpanKey).(opentracing.Span); ok && span != nil {
-		var childSpan = opentracing.StartSpan(
-			name,
-			opentracing.ChildOf(span.Context()),
-		)
-		return childSpan, context.WithValue(ctx, SpanKey, childSpan), true
+	if span, ok := NewChildSpanFromContext(ctx, name); ok {
+		return span, context.WithValue(ctx, SpanKey, span), true
 	}
 	return nil, ctx, false
 }

--- a/ntracing/ntracing.go
+++ b/ntracing/ntracing.go
@@ -32,9 +32,9 @@ func NewChildSpanFromContext(
 func NewChildSpanAndContext(
 	ctx context.Context,
 	name string,
-) (opentracing.Span, context.Context, bool) {
+) (context.Context, opentracing.Span, bool) {
 	if span, ok := NewChildSpanFromContext(ctx, name); ok {
-		return span, context.WithValue(ctx, SpanKey, span), true
+		return context.WithValue(ctx, SpanKey, span), span, true
 	}
-	return nil, ctx, false
+	return ctx, nil, false
 }

--- a/ntracing/ntracing.go
+++ b/ntracing/ntracing.go
@@ -32,9 +32,9 @@ func NewChildSpanFromContext(
 func NewChildSpanAndContext(
 	ctx context.Context,
 	name string,
-) (context.Context, opentracing.Span, bool) {
+) (context.Context, opentracing.Span) {
 	if span, ok := NewChildSpanFromContext(ctx, name); ok {
-		return context.WithValue(ctx, SpanKey, span), span, true
+		return context.WithValue(ctx, SpanKey, span), span
 	}
-	return ctx, nil, false
+	return ctx, nil
 }

--- a/ntracing/ntracing.go
+++ b/ntracing/ntracing.go
@@ -11,9 +11,13 @@ type spanKey string
 // SpanKey is the key to use to store the span in request context
 var SpanKey = spanKey("span")
 
-// NewChildSpanFromContext Generates a child span with given name if a span is found on the context
-func NewChildSpanFromContext(ctx context.Context, name string) (opentracing.Span, bool) {
-	if span, ok := ctx.Value(SpanKey).(opentracing.Span); ok {
+// NewChildSpanFromContext Generates a child span with given name
+// if a span is found on the context
+func NewChildSpanFromContext(
+	ctx context.Context,
+	name string,
+) (opentracing.Span, bool) {
+	if span, ok := ctx.Value(SpanKey).(opentracing.Span); ok && span != nil {
 		var childSpan = opentracing.StartSpan(
 			name,
 			opentracing.ChildOf(span.Context()),
@@ -21,4 +25,20 @@ func NewChildSpanFromContext(ctx context.Context, name string) (opentracing.Span
 		return childSpan, true
 	}
 	return nil, false
+}
+
+// NewChildSpanAndContext generates a child span with given name if a span is
+// found on the context and creates a new context from that child span
+func NewChildSpanAndContext(
+	ctx context.Context,
+	name string,
+) (opentracing.Span, context.Context, bool) {
+	if span, ok := ctx.Value(SpanKey).(opentracing.Span); ok && span != nil {
+		var childSpan = opentracing.StartSpan(
+			name,
+			opentracing.ChildOf(span.Context()),
+		)
+		return childSpan, context.WithValue(ctx, SpanKey, childSpan), true
+	}
+	return nil, ctx, false
 }


### PR DESCRIPTION
Adding a `NewChildSpanFromContext` to the `ntracing` package to create a child span from the span existing in the context and return the new span and a new context with the newly created span. 